### PR TITLE
Update to support multiple documents. Resolve #1

### DIFF
--- a/UseLATEX.cmake
+++ b/UseLATEX.cmake
@@ -515,8 +515,8 @@ FUNCTION(ADD_LATEX_TARGETS_INTERNAL)
     ENDIF (LATEX_FILTER_OUTPUT)
 
     # Set up target names.
-    SET(pdf_target      pdf)
-    SET(auxclean_target auxclean)
+    SET(pdf_target      ${LATEX_TARGET})
+    SET(auxclean_target ${LATEX_TARGET}_clean)
 
     # Probably not all of these will be generated, but they could be.
     # Note that the aux file is added later.
@@ -667,7 +667,7 @@ FUNCTION(ADD_LATEX_TARGETS_INTERNAL)
         COMMAND ${make_pdf_fast_command}
         DEPENDS ${make_pdf_depends}
         )
-    ADD_CUSTOM_TARGET(fast
+    ADD_CUSTOM_TARGET(fast_${LATEX_TARGET}
         DEPENDS ${output_dir}/fast_${LATEX_TARGET}.pdf)
 
     SET_DIRECTORY_PROPERTIES(.
@@ -678,6 +678,7 @@ FUNCTION(ADD_LATEX_TARGETS_INTERNAL)
         COMMENT "Cleaning auxiliary LaTeX files."
         COMMAND ${CMAKE_COMMAND} -E remove ${auxiliary_clean_files}
         )
+
 ENDFUNCTION(ADD_LATEX_TARGETS_INTERNAL)
 
 FUNCTION(ADD_LATEX_TARGETS)


### PR DESCRIPTION
This change allows to compile several documents with a single CMake file, or with several treated as subprojects. It is specially useful when compiling several reports that share resources such as styles, images, bibligraphy, etc. Compiling a single document is still possible.

The main difference is that to compile a PDF, the target is not `pdf` anymore, but the name of your main file, say MAIN for a <MAIN.tex> file. Since multiple documents are allowed, you may compile one document at once using `make MAIN1`, `make MAIN2`, and so on. However, you can type `make` or `make all`, and it will compile all documents.

Additionally, you can type `make MAIN1_clean` to delete auxiliary files generated by MAIN1, and so on, or simply type `make clean` to delete all auxiliary files.
